### PR TITLE
New action and trigger format as well as new generation and execution concept.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ This is the folder where the files that are copied during the generation reside
 Action.js is the template copied to actions
 Trigger.js is the template copied to triggers
 
+** As from now we use a generic Action and a Trigger for the the flow execution (look also to the component.json file )
+
+The action and the trigger process the tokenData object and grab the operationId which they use to query the object with the same name in the component.json. From there they get the callParams object which contains the method, the pathName and the contentType. From that point we use the values from the object to make the Swagger call as before.
+
+testAction.js is the template copied to tests
+testTrigger.js is the template copied to tests
+
+The test contain pretty much a copy of the real trigger and action. The only difference is that the whole proces is run through a loop in order to make the call to the specific API back to back.
+
+Component.json is the file where all the data for the component is stored. From the auth type till every operationId as well as the methods and the names of the paths for every action or trigger. 
+
 We add basic docker config as well as a docker ignoring file
 
 Package.json and package-lock.json with the latest dependencies which are loaded while running the build docker image command

--- a/bin/oih-gen.js
+++ b/bin/oih-gen.js
@@ -83,7 +83,7 @@ async function oihGen() {
         snapshot: options.snapshot
     });
 
-    console.log('Successfully generated. Connector has been saved in output directory:', generatePath);
+    console.log("\x1b[32m",'Successfully generated. Connector has been saved in output directory:', generatePath);
 
     q.finish();
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -331,8 +331,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 recursiveSearch(resp201);
             }
             // end of schema out
-
-
             mapSchemaFieldNames(schema, ACTION.FIELD_MAP);
             ACTION.FIELD_MAP = json(ACTION.FIELD_MAP);
             output(schemaInFile, schema);

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -251,22 +251,40 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
 
             // start of schema out
             let schemaOut = {};
-                 function finalResult(res){
-                     schemaOut = res ? res : {};
+            function recursiveSearch(resp){
+                let value; 
+                if(typeof resp === "object" && resp !== undefined){   
+                   Object.keys(resp).forEach(key => {
+                    value = resp[key];
+                    while (key !== "examples"){
+                    if(typeof value === 'object' && value !== null && value !== undefined){   
+                    if (key === "schema"){
+                            finalResult(value)
+                            return false;
+                        } else {
+                            return recursiveSearch(value);            
+                        }
+                    } else { 
+                        return false;
+                        }}
+                    })   
+                    return {title:"not found"}
                 }
-            
-        
-
-            const successResp = "200";
-            const createResp = "201";        
-            const resp200 = operation.responses[successResp];
-            const resp201 = operation.responses[createResp];
-            if(resp200){
-            finalResult(resp200["schema"]);
-             } else if (resp201) {
-            finalResult(resp201["schema"])
             }
-
+                
+            function finalResult(res){
+                schemaOut = res;
+            }
+            
+            let successResp = "200";
+            let createResp = "201";        
+            let resp200 = operation.responses[successResp];
+            let resp201 = operation.responses[createResp];
+            if(resp200 !== undefined){
+                recursiveSearch(resp200);
+            } else if(resp201 !== undefined) {
+                recursiveSearch(resp201);
+            }
             // end of schema out
 
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -143,6 +143,65 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
 
     // generate actions
     let existingNames = {};
+    let ACTION = {
+        API_TITLE: apiTitle,
+        PACKAGE_NAME: packageName,
+        // OPERATION_ID: quote(operation.operationId),
+        // METHOD: quote(method),
+        // PATH: quote(opPath),
+        PARAMETERS: [],
+        FIELD_MAP: {},
+        NOW: new Date().toISOString(),
+        GENERATOR_VERSION: require('../package.json').version,
+        SNAPSHOT: quote(snapshot)
+    };
+
+
+    ACTION.SECURITIES = ['let securities = {}'];
+    let schemeArray = [];
+    let secLength = Object.keys(api.components.securitySchemes).length
+
+    for (i = 0; i < secLength; i++) {
+        let keys = Object.keys(api.components.securitySchemes);
+        let current = keys[i]
+        schemeArray = [...schemeArray, api.components.securitySchemes[current].scheme]
+    }
+    let hasBearer = schemeArray.includes("bearer");
+
+    let usedSecurities = {};
+    for (let secReq of api.security || []) {
+        _.forOwn(secReq, (sec, key) => {
+            if (usedSecurities[key]) {
+                return;
+            }
+            usedSecurities[key] = true;
+
+            let scheme = api.components.securitySchemes[key];
+
+            if(!scheme) {
+                throw 'Security scheme not defined: ' + key;
+            }
+            let fieldName = 'auth_' + key;
+
+            if (scheme.type === 'apiKey') {
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("key") + ']');
+            }
+            if (scheme.type === 'http' && scheme.scheme === 'basic') {
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = {username: cfg.username, password: cfg.passphrase};');
+            }
+            if (scheme.type === 'http' && scheme.scheme === 'bearer') {
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("accessToken") + ']');
+            }
+            if (scheme.type === 'oauth2' && !hasBearer) {
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = { token: { access_token: cfg[' + quote("accessToken") + ']' + '} }' );
+            }
+            if (scheme.type === 'openIdConnect') {
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg.oauth2');
+            }
+        });
+    }
+    ACTION.SECURITIES = ACTION.SECURITIES.join(';\n    ') + ';';
+    
     try {
         _.forOwn(api.paths, (operations, opPath) => {
         if (opPath[0] !== '/') {
@@ -164,18 +223,18 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             }
             existingNames[name] = 1;
 
-            let ACTION = {
-                API_TITLE: apiTitle,
-                PACKAGE_NAME: packageName,
-                OPERATION_ID: quote(operation.operationId),
-                METHOD: quote(method),
-                PATH: quote(opPath),
-                PARAMETERS: [],
-                FIELD_MAP: {},
-                NOW: new Date().toISOString(),
-                GENERATOR_VERSION: require('../package.json').version,
-                SNAPSHOT: quote(snapshot)
-            };
+            // let ACTION = {
+            //     API_TITLE: apiTitle,
+            //     PACKAGE_NAME: packageName,
+            //     OPERATION_ID: quote(operation.operationId),
+            //     METHOD: quote(method),
+            //     PATH: quote(opPath),
+            //     PARAMETERS: [],
+            //     FIELD_MAP: {},
+            //     NOW: new Date().toISOString(),
+            //     GENERATOR_VERSION: require('../package.json').version,
+            //     SNAPSHOT: quote(snapshot)
+            // };
             let nameForFile = name.slice(0, 100);
             let schemaInFile = filename('lib/schemas', nameForFile + '.in.json');
             let schemaOutFile = filename('lib/schemas', nameForFile + '.out.json');
@@ -188,6 +247,10 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                         viewClass: 'CheckBoxView',
                         label: 'Debug this step (log more data)',
                     }
+                },
+                callParams: {
+                    pathName: opPath,
+                    method: method,
                 },
                 metadata: {
                     in: schemaInFile,
@@ -204,13 +267,13 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 properties: {}
             };
             _.each(Object.assign({}, pathParams, operation.parameters), param => {
-                ACTION.PARAMETERS.push(param.name);
+                // ACTION.PARAMETERS.push(param.name);
                 schema.properties[param.name] = Object.assign({
                     required: param.required,
                 }, param.schema);
                 action.$$$params.push(param);
             });
-            ACTION.PARAMETERS = json(ACTION.PARAMETERS);
+            // ACTION.PARAMETERS = json(ACTION.PARAMETERS);
 
 
             ACTION.CONTENT_TYPE = 'undefined';
@@ -245,7 +308,8 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                         model: _.zipObject(contentTypes.map(ct => ct.replace(/\./g, '%2E')), contentTypes)
                     };
                 } else if (contentTypes.length === 1) {
-                    ACTION.CONTENT_TYPE = `'${contentTypes[0]}'`;
+                    // ACTION.CONTENT_TYPE = `'${contentTypes[0]}'`;
+                    action.callParams["requestContentType"] = `${contentTypes[0]}`;
                 }
             }
 
@@ -292,65 +356,23 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             ACTION.FIELD_MAP = json(ACTION.FIELD_MAP);
             output(schemaInFile, schema);
             output(schemaOutFile, schemaOut);
-
-            ACTION.SECURITIES = ['let securities = {}'];
-            let schemeArray = [];
-            let secLength = Object.keys(api.components.securitySchemes).length
-
-            for (i = 0; i < secLength; i++) {
-                let keys = Object.keys(api.components.securitySchemes);
-                let current = keys[i]
-                schemeArray = [...schemeArray, api.components.securitySchemes[current].scheme]
-            }
-            let hasBearer = schemeArray.includes("bearer");
-            console.log(hasBearer)
             
-            let usedSecurities = {};
-            for (let secReq of operation.security || api.security || []) {
-                _.forOwn(secReq, (sec, key) => {
-                    if (usedSecurities[key]) {
-                        return;
-                    }
-                    usedSecurities[key] = true;
+            const actionPath = quote(opPath)
 
-                    let scheme = api.components.securitySchemes[key];
-
-                    if(!scheme) {
-                        throw 'Security scheme not defined: ' + key;
-                    }
-                    let fieldName = 'auth_' + key;
-
-                    if (scheme.type === 'apiKey') {
-                        ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("key") + ']');
-                    }
-                    if (scheme.type === 'http' && scheme.scheme === 'basic') {
-                        ACTION.SECURITIES.push('securities[' + quote(key) + '] = {username: cfg.username, password: cfg.passphrase};');
-                    }
-                    if (scheme.type === 'http' && scheme.scheme === 'bearer') {
-                        ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("accessToken") + ']');
-                    }
-                    if (scheme.type === 'oauth2' && !hasBearer) {
-                        ACTION.SECURITIES.push('securities[' + quote(key) + '] = { token: { access_token: cfg[' + quote("accessToken") + ']' + '} }' );
-                    }
-                    if (scheme.type === 'openIdConnect') {
-                        ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg.oauth2');
-                    }
-                });
-            }
-            ACTION.SECURITIES = ACTION.SECURITIES.join(';\n    ') + ';';
-            
-
-            if(ACTION.METHOD === "'get'" && (ACTION.PATH.slice(-2,-1) !== "}")){
-                outputTrigger(nameForFile, ACTION);
-                action.main = filename('lib/triggers', nameForFile + '.js')
+            if(quote(method) === "'get'" && (actionPath.slice(-2,-1) !== "}")){
+                action.main = filename('lib/triggers/trigger.js')
                 componentJson.triggers[name] = action;
-
             } else {
-                outputAction(nameForFile, ACTION);
+                action.main = filename('lib/triggers/action.js')
                 componentJson.actions[name] = action;
             }
         });
     });
+
+    outputTrigger({ SECURITIES: ACTION.SECURITIES, SNAPSHOT:ACTION.SNAPSHOT, NOW: ACTION.NOW, GENERATOR_VERSION: ACTION.GENERATOR_VERSION, API_TITLE: ACTION.API_TITLE, PACKAGE_NAME: ACTION.PACKAGE_NAME });
+    outputAction({ SECURITIES: ACTION.SECURITIES, SNAPSHOT:ACTION.SNAPSHOT, NOW: ACTION.NOW, GENERATOR_VERSION: ACTION.GENERATOR_VERSION, API_TITLE: ACTION.API_TITLE, PACKAGE_NAME: ACTION.PACKAGE_NAME });
+
+
     } catch (err) {
         console.log("\x1b[31m","error",err + "\033[91m")
     }
@@ -395,14 +417,14 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
         waitFor.push(fse.outputFile(path.join(outputDir, filename), text));
     }
 
-    function outputAction(name, params) {
+    function outputAction(params) {
         let content = actionTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
-        output('lib/actions/' + name + '.js', content);
+        output('lib/actions/action.js', content);
     }
 
-    function outputTrigger(name, params) {
+    function outputTrigger(params) {
         let content = triggerTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
-        output('lib/triggers/' + name + '.js', content);
+        output('lib/triggers/trigger.js', content);
     }
 
     function quote(str) {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -196,7 +196,7 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             }
         });
     }
-    ACTION.SECURITIES = ACTION.SECURITIES.join(';\n    ') + ';';
+    ACTION.SECURITIES = ACTION.SECURITIES.join(';\n    ');
     
     try {
         _.forOwn(api.paths, (operations, opPath) => {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -29,6 +29,8 @@ const triggerTemplate = readTemplate('trigger.js');
 const eslintTemplate = readTemplate('.eslintrc.js');
 const packagelockTemplate = readTemplate('package-lock.json');
 const helpersTemplate = readTemplate('helpers.js');
+const testAction = readTemplate('testAction.js');
+const testTrigger = readTemplate('testTrigger.js');
 
 // const wrapperTemplate = readTemplate('process-wrapper.js');
 
@@ -131,6 +133,8 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
     }));
     
     output('lib/utils/helpers.js',helpersTemplate);
+    output('lib/tests/testAction.js',testAction);
+    output('lib/tests/testTrigger.js',testTrigger);
 
     let componentJson = Object.assign(JSON.parse(componentTemplate), {
         title: apiTitle,
@@ -183,7 +187,7 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("key") + ']');
             }
             if (scheme.type === 'http' && scheme.scheme === 'basic') {
-                ACTION.SECURITIES.push('securities[' + quote(key) + '] = {username: cfg.username, password: cfg.passphrase};');
+                ACTION.SECURITIES.push('securities[' + quote(key) + '] = {username: cfg.username, password: cfg.passphrase}');
             }
             if (scheme.type === 'http' && scheme.scheme === 'bearer') {
                 ACTION.SECURITIES.push('securities[' + quote(key) + '] = cfg[' + quote("accessToken") + ']');
@@ -331,8 +335,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 recursiveSearch(resp201);
             }
             // end of schema out
-            mapSchemaFieldNames(schema, ACTION.FIELD_MAP);
-            ACTION.FIELD_MAP = json(ACTION.FIELD_MAP);
             output(schemaInFile, schema);
             output(schemaOutFile, schemaOut);
             

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -133,8 +133,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
     }));
     
     output('lib/utils/helpers.js',helpersTemplate);
-    output('lib/tests/testAction.js',testAction);
-    output('lib/tests/testTrigger.js',testTrigger);
 
     let componentJson = Object.assign(JSON.parse(componentTemplate), {
         title: apiTitle,
@@ -352,6 +350,8 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
 
     outputTrigger(ACTION);
     outputAction(ACTION);
+    outputTrigger(ACTION, true);
+    outputAction(ACTION, true);
     } catch (err) {
         console.log("\x1b[31m","error",err + "\033[91m")
     }
@@ -396,14 +396,14 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
         waitFor.push(fse.outputFile(path.join(outputDir, filename), text));
     }
 
-    function outputAction(params) {
-        let content = actionTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
-        output('lib/actions/action.js', content);
+    function outputAction(params,test = false) {
+        let content = test ? testAction.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]) : actionTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
+        test ? output('lib/tests/testAction.js', content) : output('lib/actions/action.js', content);
     }
 
-    function outputTrigger(params) {
-        let content = triggerTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
-        output('lib/triggers/trigger.js', content);
+    function outputTrigger(params, test = false) {
+        let content = test ? testTrigger.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]) : triggerTemplate.replace(/\$([a-z_0-9]+)/ig, (match, p1) => params[p1]);
+        test ? output('lib/tests/testTrigger.js', content) : output('lib/triggers/trigger.js', content);
     }
 
     function quote(str) {

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -146,10 +146,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
     let ACTION = {
         API_TITLE: apiTitle,
         PACKAGE_NAME: packageName,
-        // OPERATION_ID: quote(operation.operationId),
-        // METHOD: quote(method),
-        // PATH: quote(opPath),
-        PARAMETERS: [],
         FIELD_MAP: {},
         NOW: new Date().toISOString(),
         GENERATOR_VERSION: require('../package.json').version,
@@ -223,18 +219,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             }
             existingNames[name] = 1;
 
-            // let ACTION = {
-            //     API_TITLE: apiTitle,
-            //     PACKAGE_NAME: packageName,
-            //     OPERATION_ID: quote(operation.operationId),
-            //     METHOD: quote(method),
-            //     PATH: quote(opPath),
-            //     PARAMETERS: [],
-            //     FIELD_MAP: {},
-            //     NOW: new Date().toISOString(),
-            //     GENERATOR_VERSION: require('../package.json').version,
-            //     SNAPSHOT: quote(snapshot)
-            // };
             let nameForFile = name.slice(0, 100);
             let schemaInFile = filename('lib/schemas', nameForFile + '.in.json');
             let schemaOutFile = filename('lib/schemas', nameForFile + '.out.json');
@@ -267,14 +251,11 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 properties: {}
             };
             _.each(Object.assign({}, pathParams, operation.parameters), param => {
-                // ACTION.PARAMETERS.push(param.name);
                 schema.properties[param.name] = Object.assign({
                     required: param.required,
                 }, param.schema);
                 action.$$$params.push(param);
             });
-            // ACTION.PARAMETERS = json(ACTION.PARAMETERS);
-
 
             ACTION.CONTENT_TYPE = 'undefined';
 
@@ -363,16 +344,14 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
                 action.main = filename('lib/triggers/trigger.js')
                 componentJson.triggers[name] = action;
             } else {
-                action.main = filename('lib/triggers/action.js')
+                action.main = filename('lib/actions/action.js')
                 componentJson.actions[name] = action;
             }
         });
     });
 
-    outputTrigger({ SECURITIES: ACTION.SECURITIES, SNAPSHOT:ACTION.SNAPSHOT, NOW: ACTION.NOW, GENERATOR_VERSION: ACTION.GENERATOR_VERSION, API_TITLE: ACTION.API_TITLE, PACKAGE_NAME: ACTION.PACKAGE_NAME });
-    outputAction({ SECURITIES: ACTION.SECURITIES, SNAPSHOT:ACTION.SNAPSHOT, NOW: ACTION.NOW, GENERATOR_VERSION: ACTION.GENERATOR_VERSION, API_TITLE: ACTION.API_TITLE, PACKAGE_NAME: ACTION.PACKAGE_NAME });
-
-
+    outputTrigger(ACTION);
+    outputAction(ACTION);
     } catch (err) {
         console.log("\x1b[31m","error",err + "\033[91m")
     }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -143,7 +143,8 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
 
     // generate actions
     let existingNames = {};
-    _.forOwn(api.paths, (operations, opPath) => {
+    try {
+        _.forOwn(api.paths, (operations, opPath) => {
         if (opPath[0] !== '/') {
             return;
         } // skip x-* fields
@@ -249,55 +250,22 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             }
 
             // start of schema out
-            let schemaOut = {            };
-            
-
-            let searchKey = ["items","schema","attributes"];
-
-            let path = "";
-
-            const recursiveSearch = (resp) => {
-                let value; 
-                if(typeof resp === "object" && resp !== undefined){   
-                   Object.keys(resp).forEach(key => {
-                    value = resp[key];
-                    while (key !== "examples"){
-                    if(typeof value === 'object' && value !== null && value !== undefined){   
-                        path = path +"."+ key;
-                        let latestPath = ACTION.PATH.split("/").pop();
-
-                    if (key === "schema"){
-                            finalResult(value)
-                            return false;
-                        }else if (path.split(".").pop() === "attributes" && (!value.data) && (!value.items)){
-                            finalResult(value);
-
-                            return value;
-                        } else {
-                            return recursiveSearch(value);            
-                        }
-                        
-                    } else { 
-                        return false;
-                        }}
-            
-                    })   
-                    return {title:"not found"}
-                }
-            
-            }
+            let schemaOut = {};
                  function finalResult(res){
-                     schemaOut = res;
+                     schemaOut = res ? res : {};
                 }
             
         
 
-        const successResp = "200";
-        const resp200 = operation.responses[successResp];
-        // console.log("resp200",resp200);
-        if(resp200 !== undefined){
-        recursiveSearch(resp200);
-    }
+            const successResp = "200";
+            const createResp = "201";        
+            const resp200 = operation.responses[successResp];
+            const resp201 = operation.responses[createResp];
+            if(resp200){
+            finalResult(resp200["schema"]);
+             } else if (resp201) {
+            finalResult(resp201["schema"])
+            }
 
             // end of schema out
 
@@ -355,10 +323,6 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             
 
             if(ACTION.METHOD === "'get'" && (ACTION.PATH.slice(-2,-1) !== "}")){
-
-                // console.log("method",ACTION.PATH.slice(-2,-1));
-                // console.log("path",ACTION.PATH);
-                // console.log("included",ACTION.PATH.includes("{"));
                 outputTrigger(nameForFile, ACTION);
                 action.main = filename('lib/triggers', nameForFile + '.js')
                 componentJson.triggers[name] = action;
@@ -369,6 +333,10 @@ module.exports = async function generate({inputFile, outputDir, packageName, swa
             }
         });
     });
+    } catch (err) {
+        console.log("\x1b[31m","error",err + "\033[91m")
+    }
+    
 
     transliterateObject(componentJson);
     output('component.json', componentJson);
@@ -525,7 +493,6 @@ function addCredentials(comp, api) {
         }
     }
 
-    //console.log('spec', json(api));
     _.forOwn(schemes, (scheme, key) => {
         let fieldName = 'auth_' + key;
         if (scheme.type === 'apiKey') {

--- a/templates/action.js
+++ b/templates/action.js
@@ -16,7 +16,7 @@ const spec = require("../spec.json");
 const { mapFieldNames, getMetadata } = require("../utils/helpers");
 const componentJson = require("../../component.json");
 
-function processAction(msg, cfg, data) {
+function processAction(msg, cfg, _s, _h, data) {
   var isVerbose = process.env.debug || cfg.verbose;
 
   console.log("data function:", data["function"]);

--- a/templates/action.js
+++ b/templates/action.js
@@ -16,10 +16,10 @@ const spec = require("../spec.json");
 const { mapFieldNames, getMetadata } = require("../utils/helpers");
 const componentJson = require("../../component.json");
 
-function processAction(msg, cfg, _s, _h, data) {
+function processAction(msg, cfg, snapshot, incomingMessageHeaders, tokenData) {
   var isVerbose = process.env.debug || cfg.verbose;
 
-  console.log("data function:", data["function"]);
+  console.log("data function:", tokenData["function"]);
   console.log("msg:", msg);
   console.log("cfg:", cfg);
 

--- a/templates/action.js
+++ b/templates/action.js
@@ -29,7 +29,7 @@ function processAction(msg, cfg, data) {
     console.log(`---ENV: ${JSON.stringify(process.env)}`);
   }
   const action = componentJson.actions[data["function"]];
-  const { pathName, method, contentType } = action.callParams;
+  const { pathName, method, requestContentType } = action.callParams;
 
   const specPath = spec.paths[pathName];
   const specPathParameters = specPath[method].parameters.map(({ name }) => {
@@ -61,7 +61,7 @@ function processAction(msg, cfg, data) {
     pathName: pathName,
     method: method,
     parameters: parameters,
-    requestContentType: contentType,
+    requestContentType: requestContentType,
     requestBody: body,
     securities: { authorized: securities },
     server: spec.servers[cfg.server] || cfg.otherServer,

--- a/templates/action.js
+++ b/templates/action.js
@@ -43,9 +43,7 @@ function processAction(msg, cfg, data) {
   for (let param of specPathParameters) {
     parameters[param] = body[param];
   }
-
-  const newElement = {};
-
+  
   $SECURITIES;
 
   if (cfg.otherServer) {
@@ -76,6 +74,7 @@ function processAction(msg, cfg, data) {
     console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
   }
 
+  const newElement = {};
   // Call operation via Swagger client
   return Swagger.execute(callParams).then((data) => {
     // emit a single message with data

--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -1,4 +1,4 @@
-const dayjs = require('dayjs')
+const dayjs = require("dayjs");
 
 function isSecondDateAfter(a, b) {
   return dayjs(a).isAfter(b);
@@ -7,10 +7,21 @@ function isSecondDateAfter(a, b) {
 function mapFieldNames(obj) {
   if (Array.isArray(obj)) {
     obj.forEach(mapFieldNames);
-  } else if (typeof obj === 'object' && obj) {
+  } else if (typeof obj === "object" && obj) {
     obj = Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null));
     return obj;
   }
 }
+function getMetadata(metadata) {
+  const metadataKeys = ["oihUid", "recordUid", "applicationUid"];
+  let newMetadata = {};
+  for (let i = 0; i < metadataKeys.length; i++) {
+    newMetadata[metadataKeys[i]] =
+      metadata !== undefined && metadata[metadataKeys[i]] !== undefined
+        ? metadata[metadataKeys[i]]
+        : `${metadataKeys[i]} not set yet`;
+  }
+  return newMetadata;
+}
 
-module.exports = { isSecondDateAfter, mapFieldNames };
+module.exports = { isSecondDateAfter, mapFieldNames, getMetadata };

--- a/templates/package.json
+++ b/templates/package.json
@@ -7,9 +7,9 @@
         "dayjs": "^1.10.7"
     },
     "devDependencies": {
-        "eslint": "7.26.0",
-        "eslint-config-airbnb-base": "13.1.0",
-        "eslint-plugin-import": "2.14.0",
+        "eslint": "8.8.0",
+        "eslint-config-airbnb-base": "15.0.0",
+        "eslint-plugin-import": "2.25.4",
         "eslint-plugin-jest": "22.1.0",
         "eslint-plugin-json": "1.4.0",
         "eslint-plugin-mocha": "5.2.0"

--- a/templates/testAction.js
+++ b/templates/testAction.js
@@ -1,0 +1,94 @@
+/**
+ * Auto-generated test action file for "$API_TITLE" API.
+ * Generated at: $NOW
+ * Mass generator version: $GENERATOR_VERSION
+ *
+ * : $PACKAGE_NAME
+ * Copyright © 2020,  AG
+ *
+ * All files of this connector are licensed under the Apache 2.0 License. For details
+ * see the file LICENSE on the toplevel directory.
+ *
+ */
+
+ const Swagger = require("swagger-client");
+ const spec = require("../spec.json");
+ const { mapFieldNames, getMetadata } = require("../utils/helpers");
+ const componentJson = require("../../component.json");
+ 
+ function processAction(msg, cfg, _s, _h, data) {
+   var isVerbose = process.env.debug || cfg.verbose;
+ 
+   console.log("data function:", data["function"]);
+   console.log("msg:", msg);
+   console.log("cfg:", cfg);
+ 
+   if (isVerbose) {
+     console.log(`---MSG: ${JSON.stringify(msg)}`);
+     console.log(`---CFG: ${JSON.stringify(cfg)}`);
+     console.log(`---ENV: ${JSON.stringify(process.env)}`);
+   }
+   const action = componentJson.actions[data["function"]];
+   const { pathName, method, requestContentType } = action.callParams;
+ 
+   const specPath = spec.paths[pathName];
+   const specPathParameters = specPath[method].parameters.map(({ name }) => {
+     return name;
+   });
+ 
+   const body = msg.data;
+   mapFieldNames(body);
+ 
+   let parameters = {};
+   for (let param of specPathParameters) {
+     parameters[param] = body[param];
+   }
+   
+   $SECURITIES;
+ 
+   if (cfg.otherServer) {
+     if (!spec.servers) {
+       spec.servers = [];
+     }
+     spec.servers.push({ url: cfg.otherServer });
+   }
+ 
+   let callParams = {
+     spec: spec,
+     operationId: data["function"],
+     pathName: pathName,
+     method: method,
+     parameters: parameters,
+     requestContentType: requestContentType,
+     requestBody: body,
+     securities: { authorized: securities },
+     server: spec.servers[cfg.server] || cfg.otherServer,
+   };
+   if (callParams.method === "get") {
+     delete callParams.requestBody;
+   }
+ 
+   if (isVerbose) {
+     let out = Object.assign({}, callParams);
+     out.spec = "[omitted]";
+     console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
+   }
+ 
+   const newElement = {};
+   // Call operation via Swagger client
+   return Swagger.execute(callParams).then((data) => {
+     // emit a single message with data
+     delete data.uid;
+     newElement.metadata = getMetadata(msg.metadata);
+     newElement.data = data.data;
+     console.log("Data to be emitted:",data)
+    });
+ }
+ const ids = [];
+ for (let i = 0; i < ids.length; i++ ) {
+     const msg = {};
+     const cfg = {};
+     const data = {};
+
+     processAction(msg,cfg,{},{},data)
+ }

--- a/templates/testAction.js
+++ b/templates/testAction.js
@@ -74,14 +74,13 @@
      console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
    }
  
-   const newElement = {};
    // Call operation via Swagger client
    return Swagger.execute(callParams).then((data) => {
      // emit a single message with data
-     delete data.uid;
-     newElement.metadata = getMetadata(msg.metadata);
-     newElement.data = data.data;
-     console.log("Data to be emitted:",data)
+     console.log("Status Code: ",data.status);
+     console.log("Status Text: ",data.statusText);
+     console.log("Data Object: ",data.data)
+
     });
  }
  const ids = [];
@@ -92,6 +91,8 @@
      const data = {
          "function": ids[i] 
      };
+
+     console.log(`Test for the operation ${ids[i]} !`)
 
      processAction(msg,cfg,{},{},data)
  }

--- a/templates/testAction.js
+++ b/templates/testAction.js
@@ -16,7 +16,7 @@
  const { mapFieldNames, getMetadata } = require("../utils/helpers");
  const componentJson = require("../../component.json");
  
- function processAction(msg, cfg, _s, _h, data) {
+ function processAction(msg, cfg, snapshot, incomingMessageHeaders, data) {
    var isVerbose = process.env.debug || cfg.verbose;
  
    console.log("data function:", data["function"]);
@@ -85,10 +85,13 @@
     });
  }
  const ids = [];
+ 
  for (let i = 0; i < ids.length; i++ ) {
      const msg = {};
      const cfg = {};
-     const data = {};
+     const data = {
+         "function": ids[i] 
+     };
 
      processAction(msg,cfg,{},{},data)
  }

--- a/templates/testTrigger.js
+++ b/templates/testTrigger.js
@@ -1,0 +1,139 @@
+/**
+ * Auto-generated trigger file for "$API_TITLE" API.
+ * Generated at: $NOW
+ * Mass generator version: $GENERATOR_VERSION
+ *
+ * : $PACKAGE_NAME
+ * Copyright © 2020,  AG
+ *
+ * All files of this connector are licensed under the Apache 2.0 License. For details
+ * see the file LICENSE on the toplevel directory.
+ *
+ */
+
+ const Swagger = require("swagger-client");
+ const spec = require("../spec.json");
+ const {
+   isSecondDateAfter,
+   mapFieldNames,
+   getMetadata,
+ } = require("../utils/helpers");
+ const componentJson = require("../../component.json");
+ 
+ function processTrigger(msg, cfg, snapshot, _h, data) {
+   var isVerbose = process.env.debug || cfg.verbose;
+   snapshot.lastUpdated = snapshot.lastUpdated || new Date(0).getTime();
+ 
+   console.log("data function:", data["function"]);
+   console.log("msg:", msg);
+   console.log("cfg:", cfg);
+   const { snapshotKey, arraySplittingKey, syncParam } = cfg.nodeSettings;
+   const trigger = componentJson.triggers[data["function"]];
+   const { pathName, method, requestContentType } = trigger.callParams;
+ 
+   const specPath = spec.paths[pathName];
+   const specPathParameters = specPath[method].parameters.map(({ name }) => {
+     return name;
+   });
+ 
+   if (isVerbose) {
+     console.log(`---MSG: ${JSON.stringify(msg)}`);
+     console.log(`---CFG: ${JSON.stringify(cfg)}`);
+     console.log(`---ENV: ${JSON.stringify(process.env)}`);
+   }
+ 
+   const body = msg.data;
+   mapFieldNames(body);
+ 
+   let parameters = {};
+   for (let param of specPathParameters) {
+     parameters[param] = body[param];
+   }
+   if (syncParam) {
+     parameters[syncParam] = snapshot.lastUpdated;
+   }
+ 
+   $SECURITIES;
+ 
+   if (cfg.otherServer) {
+     if (!spec.servers) {
+       spec.servers = [];
+     }
+     spec.servers.push({ url: cfg.otherServer });
+   }
+ 
+   let callParams = {
+     spec: spec,
+     operationId: data["function"],
+     pathName: pathName,
+     method: method,
+     parameters: parameters,
+     requestContentType: requestContentType,
+     requestBody: body,
+     securities: { authorized: securities },
+     server: spec.servers[cfg.server] || cfg.otherServer,
+   };
+   if (callParams.method === "get") {
+     delete callParams.requestBody;
+   }
+ 
+   if (isVerbose) {
+     let out = Object.assign({}, callParams);
+     out.spec = "[omitted]";
+     console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
+   }
+   const newElement = {};
+ 
+   // Call operation via Swagger client
+   return Swagger.execute(callParams).then((data) => {
+     delete data.uid;
+     newElement.metadata = getMetadata(msg.metadata);
+     const response = JSON.parse(data.data);
+ 
+     if (!arraySplittingKey) {
+       newElement.data = response;
+     } else {
+       newElement.data = arraySplittingKey
+         .split(".")
+         .reduce((p, c) => (p && p[c]) || null, response);
+     }
+     if (Array.isArray(newElement.data)) {
+       let lastElement = 0;
+       for (let i = 0; i < newElement.data.length; i++) {
+         const newObject = { ...newElement, data: newElement.data[i] };
+         const currentObjectDate = newObject.data[snapshotKey]
+           ? newObject.data[snapshotKey]
+           : newObject.data[$SNAPSHOT];
+         if (snapshot.lastUpdated === 0) {
+           if (isSecondDateAfter(currentObjectDate, lastElement)) {
+             lastElement = snapshotKey
+               ? newElement.data[snapshotKey]
+               : newElement.data[$SNAPSHOT];
+           }
+           console.log("Data to be emitted:", newObject);
+         } else {
+           if (isSecondDateAfter(currentObjectDate, snapshot.lastUpdated)) {
+             if (isSecondDateAfter(currentObjectDate, lastElement)) {
+               lastElement = currentObjectDate;
+             }
+             console.log("Data to be emitted:", newObject);
+           }
+         }
+       }
+       snapshot.lastUpdated =
+         lastElement !== 0 ? lastElement : snapshot.lastUpdated;
+       console.log("Snapshot to be emitted:", snapshot);
+        } else {
+       console.log("Data to be emitted:", newElement);
+     }
+   });
+ }
+ 
+ const ids = [];
+ for (let i = 0; i < ids.length; i++ ) {
+    const msg = {};
+    const cfg = {};
+    const data = {};
+    
+    processTrigger(msg,cfg,{},{},data)
+}

--- a/templates/testTrigger.js
+++ b/templates/testTrigger.js
@@ -82,50 +82,12 @@
      out.spec = "[omitted]";
      console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
    }
-   const newElement = {};
  
    // Call operation via Swagger client
    return Swagger.execute(callParams).then((data) => {
-     delete data.uid;
-     newElement.metadata = getMetadata(msg.metadata);
-     const response = JSON.parse(data.data);
- 
-     if (!arraySplittingKey) {
-       newElement.data = response;
-     } else {
-       newElement.data = arraySplittingKey
-         .split(".")
-         .reduce((p, c) => (p && p[c]) || null, response);
-     }
-     if (Array.isArray(newElement.data)) {
-       let lastElement = 0;
-       for (let i = 0; i < newElement.data.length; i++) {
-         const newObject = { ...newElement, data: newElement.data[i] };
-         const currentObjectDate = newObject.data[snapshotKey]
-           ? newObject.data[snapshotKey]
-           : newObject.data[$SNAPSHOT];
-         if (snapshot.lastUpdated === 0) {
-           if (isSecondDateAfter(currentObjectDate, lastElement)) {
-             lastElement = snapshotKey
-               ? newElement.data[snapshotKey]
-               : newElement.data[$SNAPSHOT];
-           }
-           console.log("Data to be emitted:", newObject);
-         } else {
-           if (isSecondDateAfter(currentObjectDate, snapshot.lastUpdated)) {
-             if (isSecondDateAfter(currentObjectDate, lastElement)) {
-               lastElement = currentObjectDate;
-             }
-             console.log("Data to be emitted:", newObject);
-           }
-         }
-       }
-       snapshot.lastUpdated =
-         lastElement !== 0 ? lastElement : snapshot.lastUpdated;
-       console.log("Snapshot to be emitted:", snapshot);
-        } else {
-       console.log("Data to be emitted:", newElement);
-     }
+    console.log("Status Code: ",data.status);
+    console.log("Status Text: ",data.statusText);
+    console.log("Data Object: ",JSON.parse(data.data))
    });
  }
  
@@ -136,6 +98,7 @@
     const data = {
         "function": ids[i] 
     };
-    
+    console.log(`Test for the operation ${ids[i]} !`)
+
     processTrigger(msg,cfg,{},{},data)
 }

--- a/templates/testTrigger.js
+++ b/templates/testTrigger.js
@@ -20,7 +20,7 @@
  } = require("../utils/helpers");
  const componentJson = require("../../component.json");
  
- function processTrigger(msg, cfg, snapshot, _h, data) {
+ function processTrigger(msg, cfg, snapshot, incomingMessageHeaders, data) {
    var isVerbose = process.env.debug || cfg.verbose;
    snapshot.lastUpdated = snapshot.lastUpdated || new Date(0).getTime();
  
@@ -133,7 +133,9 @@
  for (let i = 0; i < ids.length; i++ ) {
     const msg = {};
     const cfg = {};
-    const data = {};
+    const data = {
+        "function": ids[i] 
+    };
     
     processTrigger(msg,cfg,{},{},data)
 }

--- a/templates/trigger.js
+++ b/templates/trigger.js
@@ -20,11 +20,11 @@ const {
 } = require("../utils/helpers");
 const componentJson = require("../../component.json");
 
-function processTrigger(msg, cfg, snapshot, _h, data) {
+function processTrigger(msg, cfg, snapshot, incomingMessageHeaders, tokenData) {
   var isVerbose = process.env.debug || cfg.verbose;
   snapshot.lastUpdated = snapshot.lastUpdated || new Date(0).getTime();
 
-  console.log("data function:", data["function"]);
+  console.log("data function:", tokenData["function"]);
   console.log("msg:", msg);
   console.log("cfg:", cfg);
   const { snapshotKey, arraySplittingKey, syncParam } = cfg.nodeSettings;

--- a/templates/trigger.js
+++ b/templates/trigger.js
@@ -53,8 +53,6 @@ function processTrigger(msg, cfg, snapshot = {}, data) {
     parameters[syncParam] = snapshot.lastUpdated;
   }
 
-  const newElement = {};
-
   $SECURITIES;
 
   if (cfg.otherServer) {
@@ -84,6 +82,7 @@ function processTrigger(msg, cfg, snapshot = {}, data) {
     out.spec = "[omitted]";
     console.log(`--SWAGGER CALL: ${JSON.stringify(out)}`);
   }
+  const newElement = {};
 
   // Call operation via Swagger client
   return Swagger.execute(callParams).then((data) => {

--- a/templates/trigger.js
+++ b/templates/trigger.js
@@ -29,7 +29,7 @@ function processTrigger(msg, cfg, snapshot = {}, data) {
   console.log("cfg:", cfg);
   const { snapshotKey, arraySplittingKey, syncParam } = cfg.nodeSettings;
   const trigger = componentJson.triggers[data["function"]];
-  const { pathName, method, contentType } = trigger.callParams;
+  const { pathName, method, requestContentType } = trigger.callParams;
 
   const specPath = spec.paths[pathName];
   const specPathParameters = specPath[method].parameters.map(({ name }) => {
@@ -70,7 +70,7 @@ function processTrigger(msg, cfg, snapshot = {}, data) {
     pathName: pathName,
     method: method,
     parameters: parameters,
-    requestContentType: contentType,
+    requestContentType: requestContentType,
     requestBody: body,
     securities: { authorized: securities },
     server: spec.servers[cfg.server] || cfg.otherServer,

--- a/templates/trigger.js
+++ b/templates/trigger.js
@@ -20,7 +20,7 @@ const {
 } = require("../utils/helpers");
 const componentJson = require("../../component.json");
 
-function processTrigger(msg, cfg, snapshot = {}, data) {
+function processTrigger(msg, cfg, snapshot, _h, data) {
   var isVerbose = process.env.debug || cfg.verbose;
   snapshot.lastUpdated = snapshot.lastUpdated || new Date(0).getTime();
 


### PR DESCRIPTION
- Added the old recursion function to be able to get the schema object from every response
- Changed the way action and triggers are set up. The setup starts with the data object coming in the trigger and action which contains the operationId for the current function
- With that string we can query the `component.json` and get the `callParams object` which is now resides there
- We have the pathName, method and the `requestContentType` strings which are necessary for every swagger client call
- From now on only one trigger and one action is needed for every component as the necessary data for every case is stored in the `component.json`
- Extracted the Id Linking functionality from the action and trigger and added the function in the `helpers.js` file
- Cleaned up the `generate.js` file to match the functionality we wanted for the above
- Removed some more old comments and code from the action/trigger templates
- Created test files for the action and the trigger 
- Added `skip snapshot` functionality in the triggers
- Thinned out the code from the trigger file to the `helpers.js`