### PR TITLE
InitialSnapshot support

### DIFF
--- a/templates/lib/triggers/trigger.js
+++ b/templates/lib/triggers/trigger.js
@@ -12,7 +12,7 @@
  */
 
 const spec = require("../spec.json");
-const { dataAndSnapshot, getMetadata, getElementDataFromResponse, executeCall } = require("../utils/helpers");
+const { dataAndSnapshot, getMetadata, getElementDataFromResponse, executeCall, getInitialSnapshotValue } = require("../utils/helpers");
 const { createPaginator } = require("../utils/paginator");
 const componentJson = require("../../component.json");
 
@@ -34,6 +34,10 @@ async function processTrigger(msg, cfg, snapshot, incomingMessageHeaders, tokenD
   logger.info('Starting to execute trigger "%s"', triggerFunction);
 
   logger.info("Incoming snapshot: %j", snapshot);
+
+  snapshot.lastUpdated = getInitialSnapshotValue(cfg, snapshot);
+
+  logger.info("Using snapshot: %j", snapshot);
 
   logger.info(
     'Trigger settings - "snapshotKey": %s, "arraySplittingKey": %s, "syncParam": %s, "skipSnapshot": %s',

--- a/templates/lib/utils/helpers.js
+++ b/templates/lib/utils/helpers.js
@@ -226,6 +226,27 @@ function getElementDataFromResponse(splittingKey, res) {
     return splittingKey.split(".").reduce((p, c) => (p && p[c]) || null, res);
   }
 }
+
+function getInitialSnapshotValue(cfg, snapshot) {
+  let initialSnapshot;
+
+  if (snapshot && snapshot.lastUpdated) {
+    initialSnapshot = snapshot.lastUpdated;
+  } else {
+    initialSnapshot = new Date(0).getTime();
+  }
+
+  if (cfg && cfg.nodeSettings && cfg.nodeSettings.initialSnapshot) {
+    const initial = dayjs(cfg.nodeSettings.initialSnapshot);
+    const incoming = dayjs(initialSnapshot);
+    if (initial.isValid && incoming.isValid && initial.isAfter(incoming)) {
+      initialSnapshot = cfg.nodeSettings.initialSnapshot;
+    }
+  }
+
+  return initialSnapshot;
+}
+
 module.exports = {
   compareDate,
   mapFieldNames,
@@ -235,4 +256,5 @@ module.exports = {
   mapFormDataBody,
   isMicrosoftJsonDate,
   executeCall,
+  getInitialSnapshotValue
 };

--- a/templates/lib/utils/helpers.test.js
+++ b/templates/lib/utils/helpers.test.js
@@ -1,6 +1,8 @@
 const {
-  isMicrosoftJsonDate
+  isMicrosoftJsonDate,
+  getInitialSnapshotValue,
 } = require("./helpers");
+const dayjs = require('dayjs');
 
 describe("Helpers", () => {
   describe("isMicrosoftJsonDate", () => {
@@ -13,5 +15,38 @@ describe("Helpers", () => {
       const date = isMicrosoftJsonDate("2020-01-01T00:00:00.000Z");
       expect(date).toEqual(null);
     });
+  });
+
+  describe("getInitialSnapshotValue", () => {
+    it("should return null date when nothing is set", () => {
+      const initialSnapshot = getInitialSnapshotValue({}, {});
+      expect(initialSnapshot).toEqual(new Date(0).getTime());
+    });
+
+    it("should return received snapshot value when no initial Snapshot is set", () => {
+      const initialSnapshot = getInitialSnapshotValue({}, { lastUpdated: dayjs('10-20-2020').format() });
+      expect(initialSnapshot).toEqual(dayjs('10-20-2020').format());
+    });
+
+    it("should return initialSnapshot value when no snapshot is received", () => {
+      const initialSnapshot = getInitialSnapshotValue({ nodeSettings: { initialSnapshot: dayjs('10-19-2020').format() } }, {});
+      expect(initialSnapshot).toEqual(dayjs('10-19-2020').format());
+    });
+
+    it("should return received snapshot value when it is newer than initial snapshot", () => {
+      const initialSnapshot = getInitialSnapshotValue({ nodeSettings: { initialSnapshot: dayjs('10-19-2020').format() } }, { lastUpdated: dayjs('10-20-2020').format() });
+      expect(initialSnapshot).toEqual(dayjs('10-20-2020').format());
+    });
+
+    it("should return initialSnapshot value when it is is newer than received snapshot", () => {
+      const initialSnapshot = getInitialSnapshotValue({ nodeSettings: { initialSnapshot: dayjs('10-21-2020').format() } }, { lastUpdated: dayjs('10-20-2020').format() });
+      expect(initialSnapshot).toEqual(dayjs('10-21-2020').format());
+    });
+
+    it("should return received snapshot if initialSnapshot is malformed", () => {
+      const initialSnapshot = getInitialSnapshotValue({ nodeSettings: { initialSnapshot: dayjs('1021-2020').format() } }, { lastUpdated: dayjs('10-20-2020').format() });
+      expect(initialSnapshot).toEqual(dayjs('10-20-2020').format());
+    });
+
   });
 });


### PR DESCRIPTION
- Generated triggers can now react to the `nodeSettings.initialSnapshot` value of a flow
- If this value is set, it will be used instead of the received `snapshot.lastUpdated` value if initialSnapshot is newer
- This allows triggers to disregard changes older than a certain user-defined date even on their first execution