### PR TITLE
Added error handling that reacts to continueOnError flag

### DIFF
--- a/templates/lib/actions/action.js
+++ b/templates/lib/actions/action.js
@@ -19,78 +19,90 @@ async function processAction(msg, cfg, snapshot, incomingMessageHeaders, tokenDa
   let logger = this.logger;
   const { logLevel } = cfg.nodeSettings;
 
-  if (["fatal", "error", "warn", "info", "debug", "trace"].includes(logLevel)) {
-    logger = this.logger.child({});
-    logger.level && logger.level(logLevel);
-  }
+  let continueOnError = false;
+  if (cfg && cfg.nodeSettings && cfg.nodeSettings.continueOnError) continueOnError = true;
 
-  logger.debug("Incoming message: %j", msg);
-  logger.trace("Incoming configuration: %j", cfg);
-  logger.debug("Incoming snapshot: %j", snapshot);
-  logger.debug("Incoming message headers: %j", incomingMessageHeaders);
-  logger.debug("Incoming token data: %j", tokenData);
+  try {
 
-  const actionFunction = tokenData["function"];
-  logger.info("Starting to execute action '%s'", actionFunction);
-
-  const action = componentJson.actions[actionFunction];
-  const { operationId, pathName, method, requestContentType } = action.callParams;
-  logger.info(
-    "Found spec callParams: 'pathName': %s, 'method': %s, 'requestContentType': %s",
-    pathName,
-    method,
-    requestContentType
-  );
-
-  const specPath = spec.paths[pathName];
-  const specPathParameters = specPath[method].parameters ? specPath[method].parameters.map(({ name }) => name) : [];
-
-  let body = msg.data;
-  mapFieldNames(body);
-  if (requestContentType === "multipart/form-data") {
-    logger.info("requestContentType multipart/form-data is defined");
-    body = await mapFormDataBody.call(this, action, body);
-  }
-
-  let parameters = {};
-  for (let param of specPathParameters) {
-    parameters[param] = body[param];
-  }
-  logger.debug("Parameters were populated from configuration: %j", parameters);
-
-  $SECURITIES;
-
-  if (cfg.otherServer) {
-    if (!spec.servers) {
-      spec.servers = [];
+    if (["fatal", "error", "warn", "info", "debug", "trace"].includes(logLevel)) {
+      logger = this.logger.child({});
+      logger.level && logger.level(logLevel);
     }
-    spec.servers.push({ url: cfg.otherServer });
-    logger.debug("Server: %s was added to spec servers array", cfg.otherServer);
+
+    logger.debug("Incoming message: %j", msg);
+    logger.trace("Incoming configuration: %j", cfg);
+    logger.debug("Incoming snapshot: %j", snapshot);
+    logger.debug("Incoming message headers: %j", incomingMessageHeaders);
+    logger.debug("Incoming token data: %j", tokenData);
+
+    const actionFunction = tokenData["function"];
+    logger.info("Starting to execute action '%s'", actionFunction);
+
+    const action = componentJson.actions[actionFunction];
+    const { operationId, pathName, method, requestContentType } = action.callParams;
+    logger.info(
+      "Found spec callParams: 'pathName': %s, 'method': %s, 'requestContentType': %s",
+      pathName,
+      method,
+      requestContentType
+    );
+
+    const specPath = spec.paths[pathName];
+    const specPathParameters = specPath[method].parameters ? specPath[method].parameters.map(({ name }) => name) : [];
+
+    let body = msg.data;
+    mapFieldNames(body);
+    if (requestContentType === "multipart/form-data") {
+      logger.info("requestContentType multipart/form-data is defined");
+      body = await mapFormDataBody.call(this, action, body);
+    }
+
+    let parameters = {};
+    for (let param of specPathParameters) {
+      parameters[param] = body[param];
+    }
+    logger.debug("Parameters were populated from configuration: %j", parameters);
+
+    $SECURITIES;
+
+    if (cfg.otherServer) {
+      if (!spec.servers) {
+        spec.servers = [];
+      }
+      spec.servers.push({ url: cfg.otherServer });
+      logger.debug("Server: %s was added to spec servers array", cfg.otherServer);
+    }
+
+    const callParams = {
+      spec: spec,
+      operationId: operationId,
+      pathName: pathName,
+      method: method,
+      parameters: parameters,
+      requestContentType: requestContentType,
+      requestBody: body,
+      securities: { authorized: securities },
+      server: spec.servers[cfg.server] || cfg.otherServer,
+    };
+    if (callParams.method === "get") {
+      delete callParams.requestBody;
+    }
+
+
+    const resp = await executeCall.call(this, callParams);
+
+    const newElement = {};
+    newElement.metadata = getMetadata(msg.metadata);
+    newElement.data = resp.body;
+    this.emit("data", newElement);
+    this.logger.info("Execution finished");
+  } catch (e) {
+    if (continueOnError === true) {
+      this.emit('data', {});
+    }
+    logger.error(e);
+    this.emit('error', e);
   }
-
-  const callParams = {
-    spec: spec,
-    operationId: operationId,
-    pathName: pathName,
-    method: method,
-    parameters: parameters,
-    requestContentType: requestContentType,
-    requestBody: body,
-    securities: { authorized: securities },
-    server: spec.servers[cfg.server] || cfg.otherServer,
-  };
-  if (callParams.method === "get") {
-    delete callParams.requestBody;
-  }
-
-
-  const resp = await executeCall.call(this, callParams);
-
-  const newElement = {};
-  newElement.metadata = getMetadata(msg.metadata);
-  newElement.data = resp.body;
-  this.emit("data", newElement);
-  this.logger.info("Execution finished");
 }
 
 module.exports = { process: processAction };

--- a/templates/lib/triggers/trigger.js
+++ b/templates/lib/triggers/trigger.js
@@ -18,137 +18,148 @@ const componentJson = require("../../component.json");
 
 async function processTrigger(msg, cfg, snapshot, incomingMessageHeaders, tokenData) {
   let logger = this.logger;
-  const { snapshotKey, arraySplittingKey, syncParam, skipSnapshot, logLevel } = cfg.nodeSettings;
+  let continueOnError = false;
+  if (cfg && cfg.nodeSettings && cfg.nodeSettings.continueOnError) continueOnError = true;
 
-  if (["fatal", "error", "warn", "info", "debug", "trace"].includes(logLevel)) {
-    logger = this.logger.child({});
-    logger.level && logger.level(logLevel);
-  }
+  try {
+    const { snapshotKey, arraySplittingKey, syncParam, skipSnapshot, logLevel } = cfg.nodeSettings;
 
-  logger.debug("Incoming message: %j", msg);
-  logger.trace("Incoming configuration: %j", cfg);
-  logger.debug("Incoming message headers: %j", incomingMessageHeaders);
-  logger.debug("Incoming token data: %j", tokenData);
+    if (["fatal", "error", "warn", "info", "debug", "trace"].includes(logLevel)) {
+      logger = this.logger.child({});
+      logger.level && logger.level(logLevel);
+    }
 
-  const triggerFunction = tokenData["function"];
-  logger.info('Starting to execute trigger "%s"', triggerFunction);
+    logger.debug("Incoming message: %j", msg);
+    logger.trace("Incoming configuration: %j", cfg);
+    logger.debug("Incoming message headers: %j", incomingMessageHeaders);
+    logger.debug("Incoming token data: %j", tokenData);
 
-  logger.info("Incoming snapshot: %j", snapshot);
+    const triggerFunction = tokenData["function"];
+    logger.info('Starting to execute trigger "%s"', triggerFunction);
 
-  snapshot.lastUpdated = getInitialSnapshotValue(cfg, snapshot);
+    logger.info("Incoming snapshot: %j", snapshot);
 
-  logger.info("Using snapshot: %j", snapshot);
+    snapshot.lastUpdated = getInitialSnapshotValue(cfg, snapshot);
 
-  logger.info(
-    'Trigger settings - "snapshotKey": %s, "arraySplittingKey": %s, "syncParam": %s, "skipSnapshot": %s',
-    snapshotKey,
-    arraySplittingKey,
-    syncParam,
-    skipSnapshot
-  );
+    logger.info("Using snapshot: %j", snapshot);
 
-  const trigger = componentJson.triggers[triggerFunction];
-  const { operationId, pathName, method, requestContentType } = trigger.callParams;
-  logger.info(
-    'Found spec callParams: "pathName": %s, "method": %s, "requestContentType": %s',
-    pathName,
-    method,
-    requestContentType
-  );
+    logger.info(
+      'Trigger settings - "snapshotKey": %s, "arraySplittingKey": %s, "syncParam": %s, "skipSnapshot": %s',
+      snapshotKey,
+      arraySplittingKey,
+      syncParam,
+      skipSnapshot
+    );
 
-  const specPath = spec.paths[pathName];
-  const specPathParameters = specPath[method].parameters ? specPath[method].parameters.map(({ name }) => name) : [];
+    const trigger = componentJson.triggers[triggerFunction];
+    const { operationId, pathName, method, requestContentType } = trigger.callParams;
+    logger.info(
+      'Found spec callParams: "pathName": %s, "method": %s, "requestContentType": %s',
+      pathName,
+      method,
+      requestContentType
+    );
 
-  let triggerParams = cfg.triggerParams;
-  if (!triggerParams) {
-    logger.debug("Trigger params was not found in cfg.triggerParams, going to look into cfg");
-    triggerParams = cfg;
-  } else {
-    logger.info("Found incoming trigger params: %j", triggerParams);
-  }
+    const specPath = spec.paths[pathName];
+    const specPathParameters = specPath[method].parameters ? specPath[method].parameters.map(({ name }) => name) : [];
 
-  let parameters = {};
-  for (let param of specPathParameters) {
-    parameters[param] = triggerParams[param];
-  }
+    let triggerParams = cfg.triggerParams;
+    if (!triggerParams) {
+      logger.debug("Trigger params was not found in cfg.triggerParams, going to look into cfg");
+      triggerParams = cfg;
+    } else {
+      logger.info("Found incoming trigger params: %j", triggerParams);
+    }
 
-  if (syncParam && snapshot.lastUpdated) {
-    if (syncParam === "$FILTER") {
-      if (!snapshotKey) {
-        throw new Error("snapshotKey params should be specified!");
+    let parameters = {};
+    for (let param of specPathParameters) {
+      parameters[param] = triggerParams[param];
+    }
+
+    if (syncParam && snapshot.lastUpdated) {
+      if (syncParam === "$FILTER") {
+        if (!snapshotKey) {
+          throw new Error("snapshotKey params should be specified!");
+        }
+        parameters[syncParam] = `${snapshotKey} gt datetime'${snapshot.lastUpdated}'`;
+      } else {
+        parameters[syncParam] = snapshot.lastUpdated;
       }
-      parameters[syncParam] = `${snapshotKey} gt datetime'${snapshot.lastUpdated}'`;
-    } else {
-      parameters[syncParam] = snapshot.lastUpdated;
     }
+    logger.debug("Parameters were populated from configuration: %j", parameters);
+
+    $SECURITIES;
+
+    if (cfg.otherServer) {
+      if (!spec.servers) {
+        spec.servers = [];
+      }
+      spec.servers.push({ url: cfg.otherServer });
+      logger.debug("Server: %s was added to spec servers array", cfg.otherServer);
+    }
+
+    const paginationConfig = $PAGINATION_CONFIG;
+
+    // if there is user provided pageSize
+    if (paginationConfig?.pageSizeOption?.fieldName) {
+      // if user specified pageSize - we take that
+      if (parameters[paginationConfig.pageSizeOption.fieldName]) {
+        paginationConfig.strategy.pageSize = parseInt(parameters[paginationConfig.pageSizeOption.fieldName]);
+      }
+      // otherwise we use a configured pageSize
+      else {
+        parameters[paginationConfig.pageSizeOption.fieldName] = paginationConfig.strategy.pageSize;
+      }
+    }
+
+    logger.info("Pagination config %j", paginationConfig);
+
+    let callParams = {
+      spec: spec,
+      operationId: operationId,
+      pathName: pathName,
+      method: method,
+      parameters: parameters,
+      requestContentType: requestContentType,
+      securities: { authorized: securities },
+      server: spec.servers[cfg.server] || cfg.otherServer,
+    };
+
+    const paginator = createPaginator(paginationConfig);
+
+    let hasMorePages = true;
+    do {
+      const { body, headers } = await executeCall.call(this, callParams);
+
+      const newElement = {};
+      newElement.metadata = getMetadata(msg.metadata);
+      newElement.data = getElementDataFromResponse.call(this, arraySplittingKey, body);
+      if (skipSnapshot) {
+        logger.info("Option skipSnapshot enabled, just going to return found data, pagination is disabled");
+        return newElement.data; //no pagination if skipping snapshot
+      } else {
+        await dataAndSnapshot.call(this, newElement, snapshot, snapshotKey, "", this);
+      }
+
+      // pagination
+      if (paginator.hasNextPage({ body, headers })) {
+        callParams = { ...callParams, parameters: { ...callParams.parameters } };
+        callParams.parameters[paginationConfig.pageTokenOption.fieldName] = paginator.getNextPageToken({ body, headers });
+        logger.info("Found the next page, going to request...");
+        hasMorePages = true;
+      } else {
+        logger.info("All pages have been received");
+        hasMorePages = false;
+      }
+    } while (hasMorePages);
+    logger.info("Execution finished");
+  } catch (e) {
+    if (continueOnError === true) {
+      this.emit('data', {})
+    }
+    logger.error(e);
+    this.emit('error', e);
   }
-  logger.debug("Parameters were populated from configuration: %j", parameters);
-
-  $SECURITIES;
-
-  if (cfg.otherServer) {
-    if (!spec.servers) {
-      spec.servers = [];
-    }
-    spec.servers.push({ url: cfg.otherServer });
-    logger.debug("Server: %s was added to spec servers array", cfg.otherServer);
-  }
-
-  const paginationConfig = $PAGINATION_CONFIG;
-
-  // if there is user provided pageSize
-  if (paginationConfig?.pageSizeOption?.fieldName) {
-    // if user specified pageSize - we take that
-    if (parameters[paginationConfig.pageSizeOption.fieldName]) {
-      paginationConfig.strategy.pageSize = parseInt(parameters[paginationConfig.pageSizeOption.fieldName]);
-    }
-    // otherwise we use a configured pageSize
-    else {
-      parameters[paginationConfig.pageSizeOption.fieldName] = paginationConfig.strategy.pageSize;
-    }
-  }
-
-  logger.info("Pagination config %j", paginationConfig);
-
-  let callParams = {
-    spec: spec,
-    operationId: operationId,
-    pathName: pathName,
-    method: method,
-    parameters: parameters,
-    requestContentType: requestContentType,
-    securities: { authorized: securities },
-    server: spec.servers[cfg.server] || cfg.otherServer,
-  };
-
-  const paginator = createPaginator(paginationConfig);
-
-  let hasMorePages = true;
-  do {
-    const { body, headers } = await executeCall.call(this, callParams);
-
-    const newElement = {};
-    newElement.metadata = getMetadata(msg.metadata);
-    newElement.data = getElementDataFromResponse.call(this, arraySplittingKey, body);
-    if (skipSnapshot) {
-      logger.info("Option skipSnapshot enabled, just going to return found data, pagination is disabled");
-      return newElement.data; //no pagination if skipping snapshot
-    } else {
-      await dataAndSnapshot.call(this, newElement, snapshot, snapshotKey, "", this);
-    }
-
-    // pagination
-    if (paginator.hasNextPage({ body, headers })) {
-      callParams = { ...callParams, parameters: { ...callParams.parameters } };
-      callParams.parameters[paginationConfig.pageTokenOption.fieldName] = paginator.getNextPageToken({ body, headers });
-      logger.info("Found the next page, going to request...");
-      hasMorePages = true;
-    } else {
-      logger.info("All pages have been received");
-      hasMorePages = false;
-    }
-  } while (hasMorePages);
-  logger.info("Execution finished");
 }
 
 module.exports = { process: processTrigger };


### PR DESCRIPTION
- When `nodeSettings.continueOnError` is set, generated components will now still emit an empty message even after encountering an error
- This allows flows to continue executing even when an intermediary step errors for whatever reason